### PR TITLE
fix: add IdentitiesOnly=yes to SSH args to prevent auth failures

### DIFF
--- a/playbooks/aws/create_infrastructure.yml
+++ b/playbooks/aws/create_infrastructure.yml
@@ -162,7 +162,7 @@
         ansible_host: "{{ public_ip }}"
         ansible_user: ec2-user
         ansible_ssh_private_key_file: "{{ key_path }}"
-        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
 
     - name: Save instance information
       ansible.builtin.copy:
@@ -194,7 +194,7 @@
                     ansible_host: {{ public_ip }}
                     ansible_user: ec2-user
                     ansible_ssh_private_key_file: {{ key_path }}
-                    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+                    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
         dest: "{{ inventory_path }}"
         mode: '0644'
 


### PR DESCRIPTION
## Summary
- Adds `IdentitiesOnly=yes` to SSH args in `create_infrastructure.yml` to prevent SSH agent from offering incorrect keys during AAP node connections, which caused authentication failures.

## Test plan
- [x] Verified SSH connectivity to EC2 instances works with the fix
- [x] Full AAP deployment completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)