### PR TITLE
fix: use AWS credential_process for auto-refreshing tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Automated deployment of Ansible Automation Platform (AAP) on AWS infrastructure 
 ```bash
 # 1. Configure credentials
 cp env-vars.sample env-vars.sh
-vim env-vars.sh                    # Update Red Hat registry credentials
+vim env-vars.sh                    # Update Red Hat registry credentials and AWS profile
+aws login                          # Authenticate with AWS (opens browser)
 source env-vars.sh
 
 # 2. Install dependencies
@@ -28,9 +29,8 @@ ansible-playbook playbooks/deploy-aap-with-content.yml
 ## Prerequisites
 
 - Python 3.8+ with Ansible Core 2.14+
-- AWS CLI configured with credentials
-- AWS Access Key ID and Secret Access Key (with EC2, VPC, and IAM permissions)
-- AWS Session Token (if using temporary credentials)
+- AWS CLI v2 configured with credentials
+- AWS permissions for EC2, VPC, and IAM
 - Red Hat subscription with registry access
 - AAP containerized setup bundle
 
@@ -76,6 +76,39 @@ ansible-playbook playbooks/aap/install-content.yml
 ```
 
 ## Configuration
+
+### AWS Credentials Setup
+
+This project uses an AWS CLI profile with `credential_process` to automatically refresh temporary credentials. This prevents token expiration during long-running playbooks (the AAP installer can take 30-40 minutes).
+
+**One-time setup:**
+
+1. Add a profile to `~/.aws/config`:
+
+   ```ini
+   [profile aap-deploy]
+   credential_process = aws configure export-credentials --profile default --format process
+   region = us-east-1
+   ```
+
+2. Log in and verify:
+
+   ```bash
+   aws login
+   aws sts get-caller-identity --profile aap-deploy
+   ```
+
+**Daily workflow:**
+
+```bash
+aws login              # authenticate once per session (opens browser)
+source env-vars.sh     # sets AWS_PROFILE=aap-deploy
+ansible-playbook playbooks/deploy-aap.yml
+```
+
+> **Note:** If you have `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` set in your environment, they will override the profile. The `env-vars.sh` script automatically unsets these variables to prevent conflicts.
+
+### Application Settings
 
 Edit `env-vars.sh` for basic settings:
 

--- a/env-vars.sample
+++ b/env-vars.sample
@@ -10,7 +10,24 @@
 # AWS Region (choose your preferred region)
 export AWS_REGION="us-east-1"
 
-# AWS Credentials (ensure your AWS CLI is configured or set these)
+# AWS Credentials - Using credential_process via AWS profile (recommended)
+# This auto-refreshes tokens from your active 'aws login' session.
+#
+# Setup (one-time):
+#   1. Add this to ~/.aws/config:
+#      [profile aap-deploy]
+#      credential_process = aws configure export-credentials --profile default --format process
+#      region = us-east-1
+#
+#   2. Run: aws login
+#   3. Verify: aws sts get-caller-identity --profile aap-deploy
+#
+export AWS_PROFILE="aap-deploy"
+
+# IMPORTANT: Unset any static credentials that would override the profile
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_CREDENTIAL_EXPIRATION 2>/dev/null
+
+# Legacy: Static credentials (NOT recommended - tokens expire after ~20 min)
 # export AWS_ACCESS_KEY_ID="your-access-key-here"
 # export AWS_SECRET_ACCESS_KEY="your-secret-key-here"
 


### PR DESCRIPTION
## Summary
- Replace static STS token exports in `env-vars.sample` with an AWS CLI profile using `credential_process` for automatic token refresh
- Update README with AWS credentials setup instructions (profile configuration, daily workflow)
- Prevents `RequestExpired` errors during long-running AAP deployments (30-40 min)

## How it works
Instead of exporting static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` (which expire after ~20 min), the new approach uses an AWS CLI profile with `credential_process`. Boto3 calls this process each time credentials are needed, getting fresh tokens from the active `aws login` session.

## Test plan
- [x] Verified `aws sts get-caller-identity --profile aap-deploy` works
- [x] Full AAP deployment (530 tasks, 40+ min) completed without credential expiration

🤖 Generated with [Claude Code](https://claude.com/claude-code)