### PR TITLE
fix: add wildcard patterns for env-vars files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ files/instance-*.txt
 .env
 .env.*
 env-vars.sh
+*-env-vars.sh
+*env-vars*.sh
 set_env.sh
 *.env
 **/secrets.*


### PR DESCRIPTION
## Summary
- Add `*-env-vars.sh` and `*env-vars*.sh` patterns to prevent accidental commits of named env-vars variants containing credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)