### PR TITLE
Add update playbook for existing AAP instances

### DIFF
--- a/playbooks/aap/tasks/pre-update.yml
+++ b/playbooks/aap/tasks/pre-update.yml
@@ -1,0 +1,179 @@
+---
+# Pre-update tasks for existing AAP instances
+# Handles bundle detection/upload, SSL certificates, and inventory generation
+# Skips first-time setup (system packages) but updates hostname if changed
+
+# --- Hostname ---
+
+- name: pre-update | Set the system hostname
+  ansible.builtin.command: >-
+    hostnamectl set-hostname {{ installer_fqdn_hostname }}
+  become: true
+  changed_when: true
+
+- name: pre-update | Ensure /etc/hosts entry for FQDN
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: '^\s*127\.0\.0\.1\s+(?!localhost).*$'
+    line: "127.0.0.1 {{ installer_fqdn_hostname }}"
+    state: present
+    backup: true
+  become: true
+
+# --- Smart bundle detection ---
+
+- name: pre-update | Find AAP setup bundles in files directory
+  ansible.builtin.find:
+    paths: "{{ project_root | default(playbook_dir + '/..') }}/files"
+    patterns: "*ansible-automation-platform-containerized-setup-bundle*.tar.gz"
+    file_type: file
+  delegate_to: localhost
+  become: false
+  register: __update_bundle_files
+
+- name: pre-update | Fail if no bundles found
+  ansible.builtin.fail:
+    msg: >-
+      No AAP setup bundle found in files/ directory.
+      Expected pattern: *ansible-automation-platform-containerized-setup-bundle*.tar.gz
+  when: __update_bundle_files.files | length == 0
+
+- name: pre-update | Select bundle by explicit version
+  ansible.builtin.set_fact:
+    __update_matched_bundles: >-
+      {{ __update_bundle_files.files |
+         selectattr('path', 'search', aap_bundle_version) | list }}
+  when: aap_bundle_version | default('') != ''
+
+- name: pre-update | Fail if explicit version not found
+  ansible.builtin.fail:
+    msg: >-
+      No bundle matching version '{{ aap_bundle_version }}' found.
+      Available bundles:
+      {% for f in __update_bundle_files.files %}
+      - {{ f.path | basename }}
+      {% endfor %}
+  when:
+    - aap_bundle_version | default('') != ''
+    - __update_matched_bundles | length == 0
+
+- name: pre-update | Select latest bundle by filename
+  ansible.builtin.set_fact:
+    __update_selected_bundle: >-
+      {{ ((__update_matched_bundles | default(__update_bundle_files.files)) |
+          sort(attribute='path') | last) }}
+
+- name: pre-update | Set bundle facts
+  ansible.builtin.set_fact:
+    bundle_file: "{{ __update_selected_bundle }}"
+    bundle_filename: "{{ __update_selected_bundle.path | basename }}"
+
+- name: pre-update | Extract version from bundle filename
+  ansible.builtin.set_fact:
+    extracted_version: >-
+      {{ bundle_filename |
+         regex_replace('.*-(\d+\.\d+-\d+(\.\d+)?)-.*', '\1') }}
+
+- name: pre-update | Display selected bundle
+  ansible.builtin.debug:
+    msg:
+      - "Selected bundle: {{ bundle_filename }}"
+      - "Version: {{ extracted_version }}"
+      - "Size: {{ (bundle_file.size / 1024 / 1024) | round(1) }} MB"
+    verbosity: 0
+
+# --- Bundle upload and extraction ---
+
+- name: pre-update | Set extracted directory name
+  ansible.builtin.set_fact:
+    extracted_dir_name: "{{ bundle_filename | regex_replace('.tar.gz$', '') }}"
+
+- name: pre-update | Check if bundle is already extracted
+  ansible.builtin.stat:
+    path: "/tmp/{{ extracted_dir_name }}"
+  register: __update_extracted_bundle
+
+- name: pre-update | Upload and extract bundle
+  when: not __update_extracted_bundle.stat.exists
+  block:
+    - name: pre-update | Check if bundle tarball exists on target
+      ansible.builtin.stat:
+        path: "/tmp/{{ bundle_filename }}"
+        get_checksum: true
+        checksum_algorithm: sha256
+      register: __update_remote_bundle
+
+    - name: pre-update | Get local bundle checksum
+      ansible.builtin.stat:
+        path: "{{ bundle_file.path }}"
+        get_checksum: true
+        checksum_algorithm: sha256
+      delegate_to: localhost
+      become: false
+      register: __update_local_bundle
+
+    - name: pre-update | Copy bundle to target
+      ansible.builtin.copy:
+        src: "{{ bundle_file.path }}"
+        dest: "/tmp/{{ bundle_filename }}"
+        mode: '0644'
+      when: >-
+        not __update_remote_bundle.stat.exists or
+        __update_remote_bundle.stat.checksum != __update_local_bundle.stat.checksum
+
+    - name: pre-update | Extract setup bundle
+      ansible.builtin.unarchive:
+        src: "/tmp/{{ bundle_filename }}"
+        dest: /tmp
+        remote_src: true
+
+    - name: pre-update | Remove bundle tarball to free disk space
+      ansible.builtin.file:
+        path: "/tmp/{{ bundle_filename }}"
+        state: absent
+
+- name: pre-update | Create symlink to extracted bundle directory
+  ansible.builtin.file:
+    src: "/tmp/{{ extracted_dir_name }}"
+    dest: "/tmp/ansible-automation-platform-containerized-setup"
+    state: link
+    force: true
+
+- name: pre-update | Set proper ownership of extracted files
+  ansible.builtin.file:
+    path: "/tmp/{{ extracted_dir_name }}"
+    owner: "{{ ansible_user | default('ec2-user') }}"
+    group: "{{ ansible_user | default('ec2-user') }}"
+    recurse: true
+    state: directory
+  become: true
+
+# --- SSL certificates ---
+
+- name: pre-update | Provision Let's Encrypt certificates
+  ansible.builtin.include_role:
+    name: letsencrypt
+  when: enable_letsencrypt | default(false) | bool
+
+# --- Generate installer inventory ---
+
+- name: pre-update | Check if installer directory exists
+  ansible.builtin.stat:
+    path: "{{ installer_directory }}"
+  register: __update_installer_dir
+
+- name: pre-update | Fail if installer directory does not exist
+  ansible.builtin.fail:
+    msg: >-
+      Installer directory {{ installer_directory }} does not exist.
+      Bundle extraction may have failed.
+  when: not __update_installer_dir.stat.exists
+
+- name: pre-update | Generate AAP installer inventory
+  ansible.builtin.template:
+    src: >-
+      {{ project_root |
+         default(playbook_dir + '/..') }}/playbooks/aap/templates/inventory.j2
+    dest: "{{ installer_directory }}/inventory.custom"
+    mode: '0644'
+    backup: true

--- a/playbooks/aap/templates/inventory.j2
+++ b/playbooks/aap/templates/inventory.j2
@@ -129,6 +129,7 @@ gateway_pg_password={{ installer_admin_pw }}
 # for upgrades or updates — otherwise AAP reverts to self-signed certificates.
 gateway_tls_cert=/etc/letsencrypt/live/{{ installer_fqdn_hostname }}/fullchain.pem
 gateway_tls_key=/etc/letsencrypt/live/{{ installer_fqdn_hostname }}/privkey.pem
+gateway_tls_remote=true
 {% if aap_include_mcp_server|bool %}
 mcp_tls_cert=/etc/letsencrypt/live/{{ installer_fqdn_hostname }}/fullchain.pem
 mcp_tls_key=/etc/letsencrypt/live/{{ installer_fqdn_hostname }}/privkey.pem

--- a/playbooks/update-aap.yml
+++ b/playbooks/update-aap.yml
@@ -1,0 +1,102 @@
+---
+# Update/upgrade an existing AAP containerized instance
+# Handles bundle upgrades, SSL changes, and component toggles
+# without re-creating infrastructure or running first-time setup
+#
+# Usage:
+#   source env-vars.sh
+#   ansible-playbook -i inventory/<instance>-hosts.yml \
+#     playbooks/update-aap.yml -e @extra-vars.yml
+#
+# For a specific bundle version:
+#   ansible-playbook -i inventory/<instance>-hosts.yml \
+#     playbooks/update-aap.yml -e @extra-vars.yml -e aap_bundle_version=2.6-8
+
+- name: Update AAP Containerized Instance
+  hosts: aap_nodes
+  become: true
+  gather_facts: true
+  vars_files:
+    - "{{ project_root | default(playbook_dir + '/..') }}/extra-vars.yml"
+
+  pre_tasks:
+    - name: Verify SSH connectivity
+      ansible.builtin.ping:
+
+    - name: Display update parameters
+      ansible.builtin.debug:
+        msg:
+          - "Updating AAP on {{ inventory_hostname }} ({{ ansible_host }})"
+          - "Target FQDN: {{ installer_fqdn_hostname }}"
+          - "Bundle version: {{ aap_bundle_version | default('latest available') }}"
+          - "Let's Encrypt: {{ enable_letsencrypt | default(false) }}"
+          - "Components: Controller={{ aap_include_controller }}, EDA={{ aap_include_eda_controller }}, Hub={{ aap_include_automation_hub }}, MCP={{ aap_include_mcp_server }}"
+        verbosity: 0
+
+  tasks:
+    - name: Import pre-update tasks
+      ansible.builtin.import_tasks: aap/tasks/pre-update.yml
+
+    - name: Display installer progress
+      ansible.builtin.debug:
+        msg: "Running AAP installer (this may take 10-15 minutes)..."
+        verbosity: 0
+
+    - name: Run AAP containerized installer
+      ansible.builtin.shell: |
+        set -o pipefail
+        cd {{ installer_directory }}
+        timeout 1800 bash -c "
+        set -o pipefail
+        ANSIBLE_COLLECTIONS_PATH={{ installer_directory }}/collections \
+        ansible-playbook -v -i inventory.custom \
+        ansible.containerized_installer.install 2>&1 | tee aap_install.log
+        exit_code=\${PIPESTATUS[0]}
+        echo \"Installation completed with exit code: \$exit_code\"
+        exit \$exit_code
+        "
+      environment:
+        ANSIBLE_HOST_KEY_CHECKING: 'False'
+      become: false
+      register: __update_installer_result
+      changed_when: __update_installer_result.rc == 0
+      failed_when: >-
+        __update_installer_result.rc != 0 and
+        __update_installer_result.rc != 124
+      async: 2400
+      poll: 30
+      timeout: 2400
+
+    - name: Display installer timeout warning
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Installer timed out after 30 minutes.
+          Check logs: {{ installer_directory }}/aap_install.log
+        verbosity: 0
+      when:
+        - __update_installer_result is defined
+        - __update_installer_result.rc == 124
+
+    - name: Import post-installation verification
+      ansible.builtin.import_tasks: aap/tasks/post-install.yml
+      when:
+        - __update_installer_result is defined
+        - __update_installer_result.rc == 0
+
+  post_tasks:
+    - name: Display update result
+      ansible.builtin.debug:
+        msg:
+          - "========================================================"
+          - "AAP UPDATE {{ 'COMPLETE' if __update_installer_result.rc == 0 else 'FAILED' }}"
+          - "========================================================"
+          - ""
+          - "Instance: {{ installer_fqdn_hostname }}"
+          - "Bundle: {{ bundle_filename | default('unknown') }}"
+          - "Version: {{ extracted_version | default('unknown') }}"
+          - ""
+          - "Web Interface: https://{{ ansible_host }}"
+          - "API Endpoint: https://{{ ansible_host }}/api/gateway/v1/"
+          - "========================================================"
+        verbosity: 0
+      when: __update_installer_result is defined

--- a/roles/letsencrypt/README.md
+++ b/roles/letsencrypt/README.md
@@ -118,6 +118,7 @@ If you re-run the AAP containerized installer manually (e.g., `./setup.sh`), inc
 ```ini
 gateway_tls_cert=/etc/letsencrypt/live/<your-domain>/fullchain.pem
 gateway_tls_key=/etc/letsencrypt/live/<your-domain>/privkey.pem
+gateway_tls_remote=true
 
 # If using MCP server:
 mcp_tls_cert=/etc/letsencrypt/live/<your-domain>/fullchain.pem

--- a/roles/letsencrypt/tasks/provider_acme.yml
+++ b/roles/letsencrypt/tasks/provider_acme.yml
@@ -4,6 +4,16 @@
 
 # --- Key and CSR generation ---
 
+- name: acme | Create base letsencrypt directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - /etc/letsencrypt
+    - "{{ letsencrypt_cert_dir }}"
+  become: true
+
 - name: acme | Create ACME key directory
   ansible.builtin.file:
     path: "{{ letsencrypt_acme_key_dir }}"
@@ -273,6 +283,19 @@
       Certificate for {{ letsencrypt_domain }} is already expired.
       Not after: {{ __letsencrypt_acme_cert_info.not_after }}
   when: __letsencrypt_acme_cert_info.expired
+
+- name: acme | Set certificate files readable by AAP user
+  ansible.builtin.file:
+    path: "{{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/{{ item.name }}"
+    owner: root
+    group: "{{ letsencrypt_aap_user }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { name: fullchain.pem, mode: '0644' }
+    - { name: cert.pem, mode: '0644' }
+    - { name: chain.pem, mode: '0644' }
+    - { name: privkey.pem, mode: '0640' }
+  become: true
 
 # --- Renewal setup ---
 


### PR DESCRIPTION
## Summary

- Add `playbooks/update-aap.yml` and `playbooks/aap/tasks/pre-update.yml` for day-2 maintenance of existing AAP instances (bundle upgrades, SSL domain changes, component toggles)
- Fix `gateway_tls_remote=true` missing from inventory template — installer needs remote-mode TLS validation when certs are on the target host
- Fix letsencrypt role directory/file permissions that blocked installer preflight checks

## Test plan

- [x] Upgraded aap-grandprix from 2.6-6 to 2.6-8 with domain change (aap-grandprix.ansible.ar → aaplm.ansible.ar)
- [x] LE cert provisioned via HTTP-01, deployed to gateway and MCP
- [x] Installer passed preflight, completed successfully
- [x] Post-install API health checks passed
- [ ] Test same-domain bundle-only upgrade (no domain change)
- [ ] Test with Route53 DNS-01 challenge

Closes #20

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>