### PR TITLE
feat(letsencrypt): staging default, first_found dispatch, ECC keys

### DIFF
--- a/env-vars.sample
+++ b/env-vars.sample
@@ -16,7 +16,7 @@ unset AWS_REGION AWS_PROFILE \
   AAP_INCLUDE_LIGHTSPEED AAP_INCLUDE_MCP_SERVER \
   AAP_DATABASE_HOST AAP_DATABASE_NAME AAP_DATABASE_USERNAME AAP_DATABASE_PASSWORD \
   AAP_CACHE_HOST AAP_CACHE_PASSWORD \
-  ENABLE_LETSENCRYPT LETSENCRYPT_EMAIL LETSENCRYPT_PROVIDER ROUTE53_HOSTED_ZONE_ID \
+  ENABLE_LETSENCRYPT LETSENCRYPT_EMAIL LETSENCRYPT_PROVIDER LETSENCRYPT_USE_PRODUCTION LETSENCRYPT_KEY_TYPE ROUTE53_HOSTED_ZONE_ID \
   LIGHTSPEED_ADMIN_USER LIGHTSPEED_ADMIN_EMAIL \
   LIGHTSPEED_CHATBOT_MODEL_URL LIGHTSPEED_CHATBOT_MODEL_API_KEY LIGHTSPEED_CHATBOT_MODEL_ID \
   LIGHTSPEED_MCP_CONTROLLER_ENABLED LIGHTSPEED_MCP_LIGHTSPEED_ENABLED \
@@ -124,6 +124,16 @@ export ENABLE_LETSENCRYPT="false"
 
 # Email for Let's Encrypt certificate notifications (required if ENABLE_LETSENCRYPT=true)
 export LETSENCRYPT_EMAIL="your-email@example.com"
+
+# Use Let's Encrypt production directory (default: false = staging)
+# Staging issues valid but untrusted certificates — safe for development/testing
+# Production has strict rate limits: 50 certificates per domain per week
+# Set to "true" only when you are ready for browser-trusted certificates
+# export LETSENCRYPT_USE_PRODUCTION="false"
+
+# Certificate key type (default: rsa)
+# Set to "ecc" for ECDSA keys (faster, smaller, but less tested with AAP)
+# export LETSENCRYPT_KEY_TYPE="rsa"
 
 # AWS Route53 Hosted Zone ID (optional)
 # If set: automates DNS A record creation and uses DNS-01 challenge (recommended)

--- a/extra-vars.yml
+++ b/extra-vars.yml
@@ -76,6 +76,10 @@ route53_hosted_zone_id: >-
   {{ lookup('env', 'ROUTE53_HOSTED_ZONE_ID') | default('', true) }}
 letsencrypt_provider: >-
   {{ lookup('env', 'LETSENCRYPT_PROVIDER') | default('acme', true) }}
+letsencrypt_use_production: >-
+  {{ lookup('env', 'LETSENCRYPT_USE_PRODUCTION') | default('false', true) | bool }}
+letsencrypt_key_type: >-
+  {{ lookup('env', 'LETSENCRYPT_KEY_TYPE') | default('rsa', true) }}
 
 # MCP Server Configuration
 mcp_allow_write_operations: >-

--- a/roles/letsencrypt/README.md
+++ b/roles/letsencrypt/README.md
@@ -30,10 +30,14 @@ ansible-galaxy collection install -r requirements.yml -p collections
 See `defaults/main.yml` for all variables. Key inputs:
 
 ```yaml
-letsencrypt_provider: acme          # or 'certbot'
+letsencrypt_provider: acme          # or 'certbot' (extensible via provider_<name>.yml)
 letsencrypt_email: you@example.com  # required
 letsencrypt_domain: aap.example.com # required (defaults to installer_fqdn_hostname)
 letsencrypt_route53_zone_id: ""     # set for DNS-01, empty for HTTP-01
+letsencrypt_use_production: false   # false = staging (safe for dev), true = production
+letsencrypt_key_type: rsa           # 'rsa' (default) or 'ecc' (ECDSA)
+letsencrypt_key_size: 2048          # RSA key size (only when key_type is 'rsa')
+letsencrypt_key_curve: secp256r1    # ECC curve (only when key_type is 'ecc')
 letsencrypt_deploy_to_aap: false    # true for standalone/post-install use
 letsencrypt_include_mcp: false      # also deploy certs to MCP server
 ```
@@ -46,6 +50,7 @@ This is the fully automated path. Set these env vars before deploying:
 
 ```bash
 export ENABLE_LETSENCRYPT="true"
+export LETSENCRYPT_USE_PRODUCTION="true"
 export LETSENCRYPT_EMAIL="you@example.com"
 export ROUTE53_HOSTED_ZONE_ID="Z0123456789"
 export INSTALLER_FQDN_HOSTNAME="aap.yourdomain.com"
@@ -159,15 +164,27 @@ Both providers set up automatic renewal via cron:
 
 Renewal includes automatic certificate deployment to the gateway (and MCP if enabled).
 
-## Testing with staging
+## Staging vs Production
 
-Set `letsencrypt_acme_directory` to the staging URL to avoid rate limits during development:
+The role defaults to the Let's Encrypt **staging** directory (`letsencrypt_use_production: false`). Staging certificates are functionally identical but not trusted by browsers. This prevents accidental rate-limit hits during development (Let's Encrypt production allows 50 certificates per domain per week).
+
+When ready for browser-trusted certificates:
 
 ```yaml
-letsencrypt_acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+letsencrypt_use_production: true
 ```
 
-Staging certificates are functionally identical but not trusted by browsers. Let's Encrypt production has strict rate limits (50 certificates per domain per week).
+Or via environment variable:
+
+```bash
+export LETSENCRYPT_USE_PRODUCTION="true"
+```
+
+You can also override the ACME directory URL directly for custom ACME-compatible CAs:
+
+```yaml
+letsencrypt_acme_directory: https://acme.example.com/directory
+```
 
 ## License
 

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -12,9 +12,26 @@ letsencrypt_domain: "{{ installer_fqdn_hostname | default('') }}"
 # If empty, HTTP-01 challenge is used instead
 letsencrypt_route53_zone_id: "{{ route53_hosted_zone_id | default('') }}"
 
-# ACME directory URL (change to staging for testing)
-# Staging: https://acme-staging-v02.api.letsencrypt.org/directory
-letsencrypt_acme_directory: https://acme-v02.api.letsencrypt.org/directory
+# Use Let's Encrypt production directory (default: false = staging)
+# Staging issues valid but untrusted certificates — safe for development
+# Production has strict rate limits: 50 certificates per domain per week
+letsencrypt_use_production: false
+
+# ACME directory URL (derived from letsencrypt_use_production)
+letsencrypt_acme_directory: >-
+  {{ (letsencrypt_use_production | bool)
+     | ternary('https://acme-v02.api.letsencrypt.org/directory',
+               'https://acme-staging-v02.api.letsencrypt.org/directory') }}
+
+# Certificate key type: 'rsa' (default) or 'ecc'
+# ECC keys are faster and smaller but untested with all AAP components
+letsencrypt_key_type: rsa
+
+# ECC curve (only used when letsencrypt_key_type is 'ecc')
+letsencrypt_key_curve: secp256r1
+
+# RSA key size (only used when letsencrypt_key_type is 'rsa')
+letsencrypt_key_size: 2048
 
 # Renew certificate when fewer than this many days remain
 letsencrypt_remaining_days: 30

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -23,6 +23,9 @@ letsencrypt_acme_directory: >-
      | ternary('https://acme-v02.api.letsencrypt.org/directory',
                'https://acme-staging-v02.api.letsencrypt.org/directory') }}
 
+# Force certificate reissue even when downgrading from production to staging
+letsencrypt_force_reissue: false
+
 # Certificate key type: 'rsa' (default) or 'ecc'
 # ECC keys are faster and smaller but untested with all AAP components
 letsencrypt_key_type: rsa

--- a/roles/letsencrypt/meta/argument_specs.yml
+++ b/roles/letsencrypt/meta/argument_specs.yml
@@ -12,10 +12,9 @@ argument_specs:
       letsencrypt_provider:
         type: str
         default: acme
-        choices:
-          - acme
-          - certbot
-        description: Certificate provisioning provider.
+        description: >-
+          Certificate provisioning provider. Built-in: 'acme', 'certbot'.
+          Extensible by adding tasks/provider_<name>.yml.
 
       letsencrypt_email:
         type: str
@@ -34,11 +33,44 @@ argument_specs:
           Route53 hosted zone ID for DNS-01 challenge.
           If empty, HTTP-01 challenge is used.
 
+      letsencrypt_use_production:
+        type: bool
+        default: false
+        description: >-
+          Use Let's Encrypt production directory. Default is false (staging).
+          Staging certificates are valid but not trusted by browsers.
+          Production has strict rate limits (50 certs/domain/week).
+
       letsencrypt_acme_directory:
         type: str
-        default: https://acme-v02.api.letsencrypt.org/directory
         description: >-
-          ACME directory URL. Use staging URL for testing.
+          ACME directory URL. Derived from letsencrypt_use_production by default.
+          Override to use a custom ACME-compatible CA.
+
+      letsencrypt_key_type:
+        type: str
+        default: rsa
+        choices:
+          - rsa
+          - ecc
+        description: >-
+          Certificate key type. RSA is the default and widely tested with AAP.
+          ECC (ECDSA) keys are faster and smaller but less tested with AAP.
+
+      letsencrypt_key_size:
+        type: int
+        default: 2048
+        description: RSA key size in bits. Only used when letsencrypt_key_type is 'rsa'.
+
+      letsencrypt_key_curve:
+        type: str
+        default: secp256r1
+        choices:
+          - secp256r1
+          - secp384r1
+        description: >-
+          ECC curve name. Only used when letsencrypt_key_type is 'ecc'.
+          secp521r1 is not supported by Let's Encrypt.
 
       letsencrypt_remaining_days:
         type: int

--- a/roles/letsencrypt/meta/argument_specs.yml
+++ b/roles/letsencrypt/meta/argument_specs.yml
@@ -48,6 +48,14 @@ argument_specs:
           ACME directory URL. Derived from letsencrypt_use_production by default.
           Override to use a custom ACME-compatible CA.
 
+      letsencrypt_force_reissue:
+        type: bool
+        default: false
+        description: >-
+          Force certificate reissue even when an existing production
+          certificate would be replaced by a staging one. Use when
+          intentionally switching from production to staging.
+
       letsencrypt_key_type:
         type: str
         default: rsa

--- a/roles/letsencrypt/meta/argument_specs.yml
+++ b/roles/letsencrypt/meta/argument_specs.yml
@@ -43,6 +43,7 @@ argument_specs:
 
       letsencrypt_acme_directory:
         type: str
+        default: https://acme-staging-v02.api.letsencrypt.org/directory
         description: >-
           ACME directory URL. Derived from letsencrypt_use_production by default.
           Override to use a custom ACME-compatible CA.

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -10,28 +10,47 @@
       letsencrypt_domain cannot be the default 'aap.example.org'.
       Set LETSENCRYPT_EMAIL and INSTALLER_FQDN_HOSTNAME in env-vars.sh.
 
-- name: Validate provider selection
+- name: Validate key type selection
   ansible.builtin.assert:
     that:
-      - letsencrypt_provider in ['acme', 'certbot']
+      - letsencrypt_key_type | lower in ['rsa', 'ecc']
     fail_msg: >-
-      letsencrypt_provider must be 'acme' or 'certbot',
-      got '{{ letsencrypt_provider }}'.
+      letsencrypt_key_type must be 'rsa' or 'ecc',
+      got '{{ letsencrypt_key_type }}'.
 
 - name: Determine challenge method
   ansible.builtin.set_fact:
     __letsencrypt_method: "{{ 'dns' if (letsencrypt_route53_zone_id | length > 0) else 'http' }}"
+
+- name: Warn when using staging ACME directory
+  ansible.builtin.debug:
+    msg: >-
+      WARNING — Using Let's Encrypt STAGING directory.
+      Certificates will NOT be trusted by browsers.
+      Set letsencrypt_use_production: true for trusted certificates.
+    verbosity: 0
+  when: not (letsencrypt_use_production | bool)
 
 - name: Display certificate provisioning plan
   ansible.builtin.debug:
     msg: >-
       Provisioning Let's Encrypt certificate for {{ letsencrypt_domain }}
       using {{ letsencrypt_provider }} provider
-      with {{ __letsencrypt_method | upper }}-01 challenge.
+      with {{ __letsencrypt_method | upper }}-01 challenge
+      ({{ (letsencrypt_use_production | bool) | ternary('PRODUCTION', 'STAGING') }},
+      {{ letsencrypt_key_type | upper }}{{ (letsencrypt_key_type | lower == 'ecc') | ternary(' ' + letsencrypt_key_curve, '') }}).
     verbosity: 0
 
 - name: Provision certificate using {{ letsencrypt_provider }} provider
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/provider_{{ letsencrypt_provider }}.yml"
+  ansible.builtin.include_tasks: >-
+    {{ lookup('first_found', __letsencrypt_provider_params) }}
+  vars:
+    __letsencrypt_provider_params:
+      files:
+        - "provider_{{ letsencrypt_provider }}.yml"
+        - provider_unknown.yml
+      paths:
+        - "{{ role_path }}/tasks"
 
 - name: Deploy certificates to AAP services
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/deploy_certs.yml"

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -31,6 +31,35 @@
     verbosity: 0
   when: not (letsencrypt_use_production | bool)
 
+- name: Check for existing certificate
+  ansible.builtin.stat:
+    path: "{{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/fullchain.pem"
+  become: true
+  register: __letsencrypt_existing_cert
+
+- name: Read existing certificate issuer
+  community.crypto.x509_certificate_info:
+    path: "{{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/fullchain.pem"
+  become: true
+  register: __letsencrypt_existing_cert_info
+  when: __letsencrypt_existing_cert.stat.exists | default(false)
+
+- name: Fail if downgrading production certificate to staging
+  ansible.builtin.fail:
+    msg: >-
+      Existing certificate for {{ letsencrypt_domain }} was issued by a
+      production CA ({{ __letsencrypt_existing_cert_info.issuer.organizationName | default('unknown') }})
+      but letsencrypt_use_production is false (staging).
+      This would replace a trusted certificate with an untrusted one.
+      Set letsencrypt_use_production: true to keep production,
+      or letsencrypt_force_reissue: true to switch to staging intentionally.
+  when:
+    - __letsencrypt_existing_cert.stat.exists | default(false)
+    - __letsencrypt_existing_cert_info.issuer.organizationName | default('') is search("Let's Encrypt")
+    - __letsencrypt_existing_cert_info.issuer.organizationName | default('') is not search("STAGING")
+    - not (letsencrypt_use_production | bool)
+    - not (letsencrypt_force_reissue | bool)
+
 - name: Display certificate provisioning plan
   ansible.builtin.debug:
     msg: >-

--- a/roles/letsencrypt/tasks/provider_acme.yml
+++ b/roles/letsencrypt/tasks/provider_acme.yml
@@ -55,13 +55,25 @@
     - __letsencrypt_privkey_stat.stat.exists | default(false)
     - __letsencrypt_privkey_stat.stat.islnk | default(false)
 
-- name: acme | Generate certificate private key
+- name: acme | Generate certificate private key (RSA)
   community.crypto.openssl_privatekey:
     path: "{{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/privkey.pem"
-    size: 2048
+    type: RSA
+    size: "{{ letsencrypt_key_size }}"
     mode: '0600'
     force: false
   become: true
+  when: letsencrypt_key_type | lower == 'rsa'
+
+- name: acme | Generate certificate private key (ECC)
+  community.crypto.openssl_privatekey:
+    path: "{{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/privkey.pem"
+    type: ECC
+    curve: "{{ letsencrypt_key_curve }}"
+    mode: '0600'
+    force: false
+  become: true
+  when: letsencrypt_key_type | lower == 'ecc'
 
 - name: acme | Generate certificate signing request
   community.crypto.openssl_csr:
@@ -414,6 +426,7 @@
     msg:
       - "Let's Encrypt certificate provisioned (acme provider)"
       - "Domain: {{ letsencrypt_domain }}"
+      - "Key type: {{ letsencrypt_key_type | upper }}{{ (letsencrypt_key_type | lower == 'ecc') | ternary(' ' + letsencrypt_key_curve, ' ' + (letsencrypt_key_size | string) + '-bit') }}"
       - "Method: {{ __letsencrypt_method | upper }}-01 challenge"
       - "Cert: {{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/fullchain.pem"
       - "Key: {{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/privkey.pem"

--- a/roles/letsencrypt/tasks/provider_certbot.yml
+++ b/roles/letsencrypt/tasks/provider_certbot.yml
@@ -39,6 +39,8 @@
     --agree-tos
     --email {{ letsencrypt_email }}
     -d {{ letsencrypt_domain }}
+    --key-type {{ (letsencrypt_key_type | lower == 'ecc') | ternary('ecdsa', 'rsa') }}
+    {{ (letsencrypt_key_type | lower == 'ecc') | ternary('--elliptic-curve ' + letsencrypt_key_curve, '--rsa-key-size ' + (letsencrypt_key_size | string)) }}
   become: true
   register: __letsencrypt_dns_result
   changed_when: >-
@@ -74,6 +76,8 @@
     --agree-tos
     --email {{ letsencrypt_email }}
     -d {{ letsencrypt_domain }}
+    --key-type {{ (letsencrypt_key_type | lower == 'ecc') | ternary('ecdsa', 'rsa') }}
+    {{ (letsencrypt_key_type | lower == 'ecc') | ternary('--elliptic-curve ' + letsencrypt_key_curve, '--rsa-key-size ' + (letsencrypt_key_size | string)) }}
     {{ __letsencrypt_certbot_pre_hook | default('') }}
     {{ __letsencrypt_certbot_post_hook | default('') }}
   become: true
@@ -128,6 +132,7 @@
     msg:
       - "Let's Encrypt certificate provisioned (certbot provider)"
       - "Domain: {{ letsencrypt_domain }}"
+      - "Key type: {{ letsencrypt_key_type | upper }}{{ (letsencrypt_key_type | lower == 'ecc') | ternary(' ' + letsencrypt_key_curve, ' ' + (letsencrypt_key_size | string) + '-bit') }}"
       - "Method: {{ __letsencrypt_method | upper }}-01 challenge"
       - "Cert: {{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/fullchain.pem"
       - "Key: {{ letsencrypt_cert_dir }}/{{ letsencrypt_domain }}/privkey.pem"

--- a/roles/letsencrypt/tasks/provider_unknown.yml
+++ b/roles/letsencrypt/tasks/provider_unknown.yml
@@ -1,0 +1,7 @@
+---
+- name: Fail on unknown provider
+  ansible.builtin.fail:
+    msg: >-
+      Unknown letsencrypt_provider '{{ letsencrypt_provider }}'.
+      Supported providers: add a tasks/provider_<name>.yml file
+      or use 'acme' (default) or 'certbot'.


### PR DESCRIPTION
## Summary

Three quick-win improvements for the letsencrypt role:

- **#9 — Default to staging ACME directory**: Adds `letsencrypt_use_production` boolean (default: `false`). Prevents accidental rate-limit burns during development. Displays a warning when using staging so users know certificates won't be browser-trusted.

- **#10 — first_found for provider dispatch**: Replaces the assert + interpolated `include_tasks` with `lookup('first_found')` and a `provider_unknown.yml` fallback. Adding a new provider is now just dropping a `tasks/provider_<name>.yml` file — no changes to `main.yml` needed.

- **#8 — ECC key support (opt-in)**: Adds `letsencrypt_key_type` (`rsa` default, `ecc` opt-in), `letsencrypt_key_size`, and `letsencrypt_key_curve` variables. Updates both acme and certbot providers. RSA stays default until ECC is tested end-to-end with AAP.

Closes #8, #9, #10

## Changes

- `roles/letsencrypt/defaults/main.yml` — new variables: `letsencrypt_use_production`, `letsencrypt_key_type`, `letsencrypt_key_size`, `letsencrypt_key_curve`; `letsencrypt_acme_directory` now derived from `letsencrypt_use_production`
- `roles/letsencrypt/tasks/main.yml` — staging warning, key type validation, `first_found` provider dispatch
- `roles/letsencrypt/tasks/provider_acme.yml` — RSA/ECC branching for `openssl_privatekey`, key type in display
- `roles/letsencrypt/tasks/provider_certbot.yml` — `--key-type` and `--elliptic-curve`/`--rsa-key-size` flags
- `roles/letsencrypt/tasks/provider_unknown.yml` — new fallback for unknown providers
- `roles/letsencrypt/meta/argument_specs.yml` — new variable specs, removed `choices` from provider
- `roles/letsencrypt/README.md` — updated variable docs, new staging/production section
- `extra-vars.yml` — wired `LETSENCRYPT_USE_PRODUCTION` and `LETSENCRYPT_KEY_TYPE`
- `env-vars.sample` — new env vars with docs, updated unset block

## Test plan

- [ ] `ansible-playbook --syntax-check` passes for deploy, update, and provision playbooks
- [ ] Deploy with staging (default) — verify warning message and staging cert
- [ ] Deploy with `letsencrypt_use_production: true` — verify production cert
- [ ] Deploy with `letsencrypt_key_type: ecc` — verify ECDSA cert generated
- [ ] Test unknown provider value — verify clean error message
- [ ] Verify certbot provider picks up `--key-type` flags correctly

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>